### PR TITLE
Change Plugin Order

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
         exclude: /node_modules/,
         query: { // use 'babel-preset-env' without transforming ES6 modules, and with added support for decorators
           presets: [['env', { modules: false }]],
-          plugins: ['transform-class-properties', 'transform-decorators-legacy']
+          plugins: [ 'transform-decorators-legacy', 'transform-class-properties']
         }
       },
       { test: /\.css$/i, 


### PR DESCRIPTION
Spent a day trying to work out why my binding on custom elements was failing.
Got it down to the fact the decorators werent firing properly.
Found this: https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#note-order-of-plugins-matters
Thanks for this repo btw